### PR TITLE
retningslinjer/107-25/arrangementer

### DIFF
--- a/src/app/retningslinjer/arrangementer/page.mdx
+++ b/src/app/retningslinjer/arrangementer/page.mdx
@@ -16,6 +16,11 @@ interessegrupper arrangerer et arrangement som oppfyller minst en av følgende k
 
 ...skal de plassere sine aktiviteter på "arrangementer".
 
+**Det finnes et unntak**:
+I den offisielle eksamensperioden, etter undervisningsslutt, kan interessegrupper plassere alle sine aktiviteter på "arrangementer", uavhengig om de oppfyller kravene ovenfor eller ikke. 
+Det er dog noe krav som stilles i et så tilfelle:
+* Banner for arrangementet må være lagd av Promo, ellers må standard banner benyttes. Det er altså **ikke** lov med egenlagd promomateriell på "arrangementer". 
+
 Komitéer og Undergrupper kan for øvrig kun benytte seg av arrangementer
 
 ## Generelle arrangementer


### PR DESCRIPTION
La til informasjon om ny retningslinje vedtatt på HS-møte 06.05.25: Interessegrupper kan nå benytte "arrangementer" fritt i eksamensperioden.