### PR TITLE
diverese/ridderordningen/redaksjonell-endring

### DIFF
--- a/src/app/riddere/page.mdx
+++ b/src/app/riddere/page.mdx
@@ -1,11 +1,11 @@
 
-# Ridderordningen
+# Ridderorden
 
 Medlemmer som har eller har hatt et aktivt verv i Hovedstyret eller undergruppene, og som har 
 gjort en særlig innsats for linjeforeningen utover vervets arbeidsoppgaver, kan utnevnes til 
 Ridder av TIHLDEs Heilage. Tittelen er livsvarig og kan foreslås av alle medlemmer i TIHLDE til 
 Hovedstyret. Dersom Hovedstyret med kvalifisert flertall mener at vedkommende er skikket, kan 
-Hovedstyret foreslå vedkommende til Ridderskapet. Ridderskapet må godkjenne vedkommende før 
+Hovedstyret foreslå vedkommende til Ridderordenen. Riddere av TIHLDEs Heilage må godkjenne vedkommende før 
 personen kan slås til Ridder. En Ridder kan kun slås til Ridder under formelle arrangementer. 
 Dette inkluderer, men er ikke begrenset til immatrikuleringsball, julebord og jubileum.
 
@@ -14,7 +14,7 @@ Som nevnt har alle medlemmer av TIHLDE rett til å nominere noen til å bli slå
 * Navn på personen du ønsker å nominere
 * Begrunnelse for hvorfor personen fortjener å bli slått til Ridder
 
-Hovedstyret vil så ved påfølgende møte vurdere skikketheten til vedkommende, før nominasjonen eventuelt blir videresendt til Ridderordningen for den endelige beslutningen.
+Hovedstyret vil så ved påfølgende møte vurdere skikketheten til vedkommende, før nominasjonen eventuelt blir videresendt til Ridderordenen for den endelige beslutningen.
 
 ## Riddere av TIHLDEs Heilage
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -239,7 +239,7 @@ export const navigation: Array<NavGroup> = [
   {
     title: 'Historie og diverse',
     links: [
-      { title: 'Ridderordningen', href: '/riddere' },
+      { title: 'Ridderorden', href: '/riddere' },
       { title: 'TIHLDEs logo', href: '/TIHLDEs-logo' },
       { title: 'TIHLDE-eden', href: '/TIHLDE-eden' },
       { title: 'Sanger', href: '/sanger' },


### PR DESCRIPTION
Fikset teksten på diverse for Ridderorden. Tidligere stod det "Ridderordningen" som er feil, det er ikke en ordning, men en orden. Ridderskapet er da også byttet ut for å bli korrekt, noe som ikke endrer intensjonen.