### PR TITLE
vedtekter/redaksjonell/114-25/oppdatering-av-Ridderorden

### DIFF
--- a/src/app/vedtekter/TIHLDEs-lover/page.mdx
+++ b/src/app/vedtekter/TIHLDEs-lover/page.mdx
@@ -220,9 +220,9 @@ bestemmelser gjelder:\
 
 Æresmedlemskapet er livsvarig, men kan fratas ved kvalifisert flertall av Generalforsamling om de i ettertid har skjemmet TIHLDEs navn og rykte.
 
-## §7 Ridderordningen
+## §7 Ridderorden
 
-Medlemmer som har gjort en særlig innsats, kan utnevnes til Ridder av TIHLDEs Heilage. Alle medlemmer kan nominere et medlem til Ridder. Dersom HS med kvalifisert flertall mener den nominerte er skikket, skal HS foreslå vedkommende for godkjenning av Ridderskapet. Riddere kan kun bli slått under formelle arrangementer. Dette inkluderer, men er ikke begrenset til immatrikuleringsball, julebord, jubileum og utmatrikuleringsball.
+Medlemmer som har gjort en særlig innsats, kan utnevnes til Ridder av TIHLDEs Heilage. Alle medlemmer kan nominere et medlem til Ridder. Dersom HS med kvalifisert flertall mener den nominerte er skikket, skal HS foreslå vedkommende for godkjenning av Ridderordenen. Riddere kan kun bli slått under formelle arrangementer. Dette inkluderer, men er ikke begrenset til immatrikuleringsball, julebord, jubileum og utmatrikuleringsball.
 
 Riddertittelen er livsvarig, men kan fratas ved kvalifisert flertall av Generalforsamling om de i ettertid har skjemmet TIHLDEs navn og rykte.
 


### PR DESCRIPTION
Fikset teksten på diverse for Ridderorden. Tidligere stod det "Ridderordningen" som er feil, det er ikke en ordning, men en orden. Ingen endring av intensjon