### PR TITLE
Fix malformed ridderorden table row

### DIFF
--- a/src/app/ridderorden/page.mdx
+++ b/src/app/ridderorden/page.mdx
@@ -29,4 +29,4 @@ Hovedstyret vil så ved påfølgende møte vurdere skikketheten til vedkommende,
 | Anna Pavelsen Sæther    | NoK, Beta, FadderKom, Økom, Redaksjonen                                | 07.06.2025     | 07.06.2025       | Utmatrikuleringsball |
 | Yrja Kibsgaard          | President 23/24, Redaksjonen, Beta                                     | 27.08.2025     | 12.09.2025       | Immatrikuleringsball |
 | Daniel Evensen          | President 25/26, Kontorminister V23/H24, KoK, Promo, Beta, IdKom       | 12.10.2024     | 12.09.2025       | Immatrikuleringsball |
-Sander Rom Skofsrud     | Leder av Beta, IdKom, ØKom                                             | 30.03.2026     | 18.04.2026       | Vårgalla             |
+| Sander Rom Skofsrud     | Leder av Beta, IdKom, ØKom                                             | 30.03.2026     | 18.04.2026       | Vårgalla             |


### PR DESCRIPTION
PR #101 la til raden for Sander Rom Skofsrud uten ledende `|`, slik at den var inkonsekvent med resten av tabellen og kunne falle ut av tabellen ved rendering. Denne raden får nå ledende pipe som alle andre rader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)