### PR TITLE
Add Idrettslag to retningslinjer navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -272,6 +272,7 @@ export const navigation: Array<NavGroup> = [
       { title: 'Utlån av TIHLDEs utstyr', href: '/retningslinjer/utlaan-utstyr'},
       { title: 'Komiteer', href: '/retningslinjer/komiteer'},
       { title: 'Interessegrupper', href: '/retningslinjer/interessegrupper'},
+      { title: 'Idrettslag', href: '/retningslinjer/idrettslag'},
       { title: 'Fordeling av ekstern pengestøtte', href: '/retningslinjer/ekstern-pengestotte'},
     ]
   },


### PR DESCRIPTION
## Problem
Idrettslag-siden (`src/app/retningslinjer/idrettslag/page.mdx`, lagt til i #100) vises ikke i sidebaren under Retningslinjer.

## Årsak
Sidebaren genereres **ikke** automatisk fra mappestrukturen — den bygges fra en manuelt vedlikeholdt liste i `src/components/Navigation.tsx`. Selve `.mdx`-filen er nok til at ruten `/retningslinjer/idrettslag` fungerer hvis man går direkte dit, men siden manglet en oppføring i navigasjonslisten, så den dukket aldri opp i menyen.

## Fikse
La til `{ title: 'Idrettslag', href: '/retningslinjer/idrettslag' }` rett etter Interessegrupper. Dette dekker både desktop og mobil, siden `MobileNavigation` rendrer samme `<Navigation />`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)