### PR TITLE
Fix react-hooks v6 violations and restore rules to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,15 +4,5 @@ import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
 export default defineConfig([
   {
     extends: [...nextCoreWebVitals],
-    rules: {
-      // `eslint-config-next` 16 enables the React Compiler (`eslint-plugin-react-hooks`
-      // v6) rules below at "error" severity. They flag long-standing patterns in the
-      // Protocol template that the previous (v14) config never checked. Downgraded to
-      // "warn" so the framework upgrade doesn't require behavioral refactors of working
-      // code; these warnings can be addressed in a dedicated follow-up.
-      'react-hooks/refs': 'warn',
-      'react-hooks/immutability': 'warn',
-      'react-hooks/set-state-in-effect': 'warn',
-    },
   },
 ])

--- a/src/components/Heading.tsx
+++ b/src/components/Heading.tsx
@@ -80,8 +80,8 @@ export function Heading<Level extends 2 | 3>({
   level?: Level
   anchor?: boolean
 }) {
-  level = level ?? (2 as Level)
-  let Component = `h${level}` as 'h2' | 'h3'
+  let resolvedLevel = level ?? (2 as Level)
+  let Component = `h${resolvedLevel}` as 'h2' | 'h3'
   let ref = useRef<HTMLHeadingElement>(null)
   let registerHeading = useSectionStore((s) => s.registerHeading)
 
@@ -91,7 +91,7 @@ export function Heading<Level extends 2 | 3>({
   })
 
   useEffect(() => {
-    if (level === 2) {
+    if (resolvedLevel === 2) {
       registerHeading({ id: props.id, ref, offsetRem: tag || label ? 8 : 6 })
     }
   })

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -53,14 +53,17 @@ function MobileNavigationDialog({
 }) {
   let pathname = usePathname()
   let searchParams = useSearchParams()
-  let initialPathname = useRef(pathname).current
-  let initialSearchParams = useRef(searchParams).current
+  let initialPathname = useRef(pathname)
+  let initialSearchParams = useRef(searchParams)
 
   useEffect(() => {
-    if (pathname !== initialPathname || searchParams !== initialSearchParams) {
+    if (
+      pathname !== initialPathname.current ||
+      searchParams !== initialSearchParams.current
+    ) {
       close()
     }
-  }, [pathname, searchParams, close, initialPathname, initialSearchParams])
+  }, [pathname, searchParams, close])
 
   function onClickDialog(event: React.MouseEvent<HTMLDivElement>) {
     if (!(event.target instanceof HTMLElement)) {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef } from 'react'
+import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import clsx from 'clsx'
@@ -20,7 +20,7 @@ interface NavGroup {
 }
 
 function useInitialValue<T>(value: T, condition = true) {
-  let initialValue = useRef(value).current
+  let [initialValue] = useState(value)
   return condition ? initialValue : value
 }
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,15 +1,14 @@
 'use client'
 
 import React, {
-  forwardRef,
   Fragment,
   Suspense,
   useCallback,
   useEffect,
   useId,
-  useImperativeHandle,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 import Highlighter from 'react-highlight-words'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -268,25 +267,28 @@ function SearchResults({
   )
 }
 
-const SearchInput = forwardRef<HTMLInputElement, {
+function SearchInput({
+  autocomplete,
+  autocompleteState,
+  onClose,
+  inputElement,
+  setInputElement,
+}: {
   autocomplete: Autocomplete
   autocompleteState: AutocompleteState<Result> | EmptyObject
   onClose: () => void
-}>(function SearchInput({ autocomplete, autocompleteState, onClose }, inputRef) {
-  const localRef = useRef<HTMLInputElement>(null)
-
-  // Tell TS this will be non-null when React applies the handle
-  useImperativeHandle(inputRef, () => localRef.current!, [])
-
+  inputElement: HTMLInputElement | null
+  setInputElement: (element: HTMLInputElement | null) => void
+}) {
   const inputProps = autocomplete.getInputProps({
-    inputElement: localRef.current,
+    inputElement,
   })
 
   return (
     <div className="group relative flex h-12">
       <SearchIcon className="pointer-events-none absolute left-3 top-0 h-full w-5 stroke-zinc-500" />
       <input
-        ref={localRef}
+        ref={setInputElement}
         data-autofocus
         className={clsx(
           'flex-auto appearance-none bg-transparent pl-10 text-zinc-900 outline-none placeholder:text-zinc-500 focus:w-full focus:flex-none sm:text-sm dark:text-white [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden [&::-webkit-search-results-button]:hidden [&::-webkit-search-results-decoration]:hidden',
@@ -318,7 +320,7 @@ const SearchInput = forwardRef<HTMLInputElement, {
       )}
     </div>
   )
-})
+}
 
 function SearchDialog({
   open,
@@ -331,7 +333,7 @@ function SearchDialog({
 }) {
   let formRef = useRef<React.ElementRef<'form'>>(null)
   let panelRef = useRef<React.ElementRef<'div'>>(null)
-  let inputRef = useRef<React.ElementRef<typeof SearchInput>>(null)
+  let [inputElement, setInputElement] = useState<HTMLInputElement | null>(null)
   let { autocomplete, autocompleteState } = useAutocomplete({
     close() {
       setOpen(false)
@@ -386,11 +388,12 @@ function SearchDialog({
             <form
               ref={formRef}
               {...autocomplete.getFormProps({
-                inputElement: inputRef.current,
+                inputElement,
               })}
             >
               <SearchInput
-                ref={inputRef}
+                inputElement={inputElement}
+                setInputElement={setInputElement}
                 autocomplete={autocomplete}
                 autocompleteState={autocompleteState}
                 onClose={() => setOpen(false)}
@@ -443,15 +446,22 @@ function useSearchProps() {
   }
 }
 
-export function Search() {
-  let [modifierKey, setModifierKey] = useState<string>()
-  let { buttonProps, dialogProps } = useSearchProps()
+const emptySubscribe = () => () => {}
 
-  useEffect(() => {
-    setModifierKey(
-      /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? '⌘' : 'Ctrl ',
-    )
-  }, [])
+// Resolve the keyboard shortcut hint without setState-in-effect. The value
+// depends on `navigator.platform`, so the server snapshot is `undefined` and
+// the client snapshot resolves after hydration.
+function useModifierKey() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => (/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? '⌘' : 'Ctrl '),
+    () => undefined,
+  )
+}
+
+export function Search() {
+  let modifierKey = useModifierKey()
+  let { buttonProps, dialogProps } = useSearchProps()
 
   return (
     <div className="hidden lg:block lg:max-w-md lg:flex-auto">

--- a/src/components/Sectionizer.tsx
+++ b/src/components/Sectionizer.tsx
@@ -33,7 +33,7 @@ import React from "react";
 export default function Sectionizer({ children, startValues = [1, 1, 1] }: { children: React.ReactNode, startValues?: number[] }) {
     
     // Supports h2 to h4
-    const actualStartValues = startValues;
+    const actualStartValues = [...startValues];
     for (let i = 0; i < 3; i++) {
         actualStartValues[i] -= 1;
     }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,5 +1,17 @@
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 import { useTheme } from 'next-themes'
+
+const emptySubscribe = () => () => {}
+
+// Hydration-safe "mounted" flag without setState-in-effect: the server snapshot
+// is `false`, and after hydration the client snapshot resolves to `true`.
+function useHasMounted() {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  )
+}
 
 function SunIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   return (
@@ -24,11 +36,7 @@ function MoonIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 export function ThemeToggle() {
   let { resolvedTheme, setTheme } = useTheme()
   let otherTheme = resolvedTheme === 'dark' ? 'light' : 'dark'
-  let [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  let mounted = useHasMounted()
 
   return (
     <button


### PR DESCRIPTION
## Summary

The Next.js 14→16 + React 19 upgrade bumped `eslint-config-next` to 16, which enables the React Compiler `eslint-plugin-react-hooks` v6 rules. To keep that PR focused, three rules (`react-hooks/refs`, `react-hooks/immutability`, `react-hooks/set-state-in-effect`) were temporarily downgraded to `warn` in `eslint.config.mjs`.

This PR fixes the 12 underlying violations and restores those rules to their default **error** severity.

## Changes

**`react-hooks/refs`** — stop reading ref `.current` during render:
- `MobileNavigation` — compare initial pathname/searchParams inside the effect rather than capturing `.current` in render.
- `Navigation` — `useInitialValue` uses a stable `useState` initializer instead of `useRef(value).current`.
- `Search` — lift the input DOM node into `useState` via a callback ref; `getInputProps`/`getFormProps` receive it from state instead of reading refs during render (removed `forwardRef`/`useImperativeHandle`).

**`react-hooks/immutability`** — avoid in-render mutation:
- `Heading` — derive a local `resolvedLevel` instead of reassigning the `level` prop.
- `Sectionizer` — copy `startValues` before decrementing.

**`react-hooks/set-state-in-effect`** — replace setState-in-effect hydration guards with `useSyncExternalStore`:
- `ThemeToggle` — mount flag.
- `Search` — modifier-key (`⌘`/`Ctrl`) hint.

**`eslint.config.mjs`** — removed the three `warn` overrides and the explanatory comment.

## Verification

- `npm run lint` — 0 errors (3 pre-existing, unrelated warnings remain).
- `npm run build` — compiles successfully.
- `npm run dev` — manually exercised each component; no console errors. Mobile nav opens on toggle and closes on route change, section numbering renders correctly (§ x.y.z), theme toggle resolves its label after hydration, search modifier key shows `⌘`, and the search dialog opens/auto-focuses/returns autocomplete results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)