### PR TITLE
feat(grupper): hent gruppedata fra Photon i stedet for Lepton

### DIFF
--- a/src/components/groups/GroupSummarizer.tsx
+++ b/src/components/groups/GroupSummarizer.tsx
@@ -1,7 +1,7 @@
 import {RenderGroupSummary} from "@/components/groups/RenderGroupSummary";
 import {remark} from "remark";
 import html from "remark-html";
-import {Group} from "@/lib/group";
+import {getGroup, Group} from "@/lib/group";
 
 /**
  * Takes either a json object of all the group information or the slug of a group and returns a
@@ -16,9 +16,7 @@ export async function GroupSummarizer({ group, slug }: | { group: Group, slug?: 
     
     // Fetch the group data if only the slug is provided
     if (slug && !group) {
-        const response = await fetch(`https://api.tihlde.org/groups/${slug}/`, { cache: "no-store" });
-        if (!response.ok) groupData = { name: "Ikke funnet", slug: slug };
-        else groupData = await response.json();
+        groupData = (await getGroup(slug)) ?? { name: "Ikke funnet", slug: slug };
     }
     
     if (!groupData) return null;

--- a/src/components/groups/GroupTypeSummarizer.tsx
+++ b/src/components/groups/GroupTypeSummarizer.tsx
@@ -1,5 +1,5 @@
 import {GroupSummarizer} from "@/components/groups/GroupSummarizer";
-import {Group} from "@/lib/group";
+import {getGroupsByType, Group} from "@/lib/group";
 
 
 /**
@@ -10,16 +10,9 @@ import {Group} from "@/lib/group";
  * @constructor
  */
 export async function GroupTypeSummarizer({ type, subtype }: { type: string; subtype?: string }) {
-    // Fetch the groups of the type
-    const query = new URLSearchParams({ type });
-    if (subtype) {
-        query.set("subtype", subtype);
-    }
+    const groups = await getGroupsByType(type, subtype);
 
-    const response = await fetch(`https://api.tihlde.org/groups/?${query.toString()}`, { cache: "no-store" });
-    const groups: Array<Group> = await response.json();
-    
-    if (!groups) return null;
+    if (!groups.length) return null;
 
     return (
         <div className="grid grid-cols-1 gap-x-12 gap sm:grid-cols-1 lg:grid-cols-2">

--- a/src/components/groups/OrgChart.tsx
+++ b/src/components/groups/OrgChart.tsx
@@ -1,21 +1,5 @@
-import { Group } from "@/lib/group";
+import { getGroup, getGroupsByType, Group } from "@/lib/group";
 import { OrgChartTree, type OrgChartData, type OrgNode } from "./OrgChartTree";
-
-async function fetchGroup(slug: string): Promise<Group | null> {
-  const res = await fetch(`https://api.tihlde.org/groups/${slug}/`, {
-    cache: "no-store",
-  });
-  if (!res.ok) return null;
-  return res.json();
-}
-
-async function fetchGroupsByType(type: string): Promise<Group[]> {
-  const res = await fetch(`https://api.tihlde.org/groups/?type=${type}`, {
-    cache: "no-store",
-  });
-  if (!res.ok) return [];
-  return res.json();
-}
 
 function toNode(group: Group): OrgNode {
   return { name: group.name, slug: group.slug, image: group.image };
@@ -29,12 +13,12 @@ const INTEREST_GROUP_SUBTYPE_LABELS: Record<string, string> = {
 export async function OrgChart() {
   const [hs, fondet, subgroups, committees, sportsTeams, interestGroups] = await Promise.all(
     [
-      fetchGroup("hs"),
-      fetchGroup("forvaltningsgruppen"),
-      fetchGroupsByType("SUBGROUP"),
-      fetchGroupsByType("COMMITTEE"),
-      fetchGroupsByType("SPORTSTEAM"),
-      fetchGroupsByType("INTERESTGROUP"),
+      getGroup("hs"),
+      getGroup("forvaltningsgruppen"),
+      getGroupsByType("SUBGROUP"),
+      getGroupsByType("COMMITTEE"),
+      getGroupsByType("SPORTSTEAM"),
+      getGroupsByType("INTERESTGROUP"),
     ],
   );
 
@@ -59,6 +43,16 @@ export async function OrgChart() {
     })
     .filter((level): level is NonNullable<typeof level> => level !== null);
 
+  // Photon only started carrying `subtype` in migration 0043, and the values
+  // are backfilled separately. Until that has run every group sorts into
+  // "UKJENT" and both sublevels come back empty — which would render the
+  // Interessegrupper heading above nothing at all. Fall back to one flat
+  // level so the groups stay on the chart either way.
+  const interestGroupLevel =
+    interestGroupSublevels.length > 0
+      ? { name: "Interessegrupper", children: [], sublevels: interestGroupSublevels }
+      : { name: "Interessegrupper", children: interestGroups.map(toNode) };
+
   const data: OrgChartData = {
     topRow: [
       hs ? toNode(hs) : { name: "Hovedstyret" },
@@ -68,7 +62,7 @@ export async function OrgChart() {
       { name: "Undergrupper", children: subgroups.map(toNode) },
       { name: "Komiteer", children: committees.map(toNode) },
       { name: "Idrettslag", children: sportsTeams.map(toNode), singleColumn: true },
-      { name: "Interessegrupper", children: [], sublevels: interestGroupSublevels },
+      interestGroupLevel,
     ],
   };
 

--- a/src/components/groups/RenderGroupSummary.tsx
+++ b/src/components/groups/RenderGroupSummary.tsx
@@ -48,7 +48,7 @@ export function RenderGroupSummary({ group, description }: { group: Group, descr
                 
                 <div className="flex flex-col">
                     <h1 className="m-0 p-0">{group.name}</h1>
-                    { group.leader && <div className="m-0">Leder: <b>{group.leader.first_name} {group.leader.last_name}</b></div> }
+                    { group.leader && <div className="m-0">Leder: <b>{group.leader.name}</b></div> }
                 </div>
             </div>
             

--- a/src/lib/group.ts
+++ b/src/lib/group.ts
@@ -1,13 +1,111 @@
+const API = process.env.PHOTON_API ?? "https://photon.tihlde.org/api";
+
+/**
+ * Group data is read straight from Photon, the site's own backend. Values
+ * change on the order of once a semester, so a five minute window keeps the
+ * wiki current without a request per group per visitor — the previous
+ * `no-store` meant every page view refetched every group.
+ */
+const REVALIDATE = { next: { revalidate: 300 } } as const;
 
 export type Group = {
-    name: string; // Name
-    slug: string; // Slug
-    subtype?: string | null; // Subtype
-    image?: string; // Image
-    contact_email?: string; // Contact email
-    description?: string; // Description
-    leader?: {
-        first_name: string; // First name
-        last_name: string; // Last name
-    }
-};    
+    name: string;
+    slug: string;
+    subtype?: string | null;
+    image?: string;
+    contact_email?: string;
+    description?: string;
+    /**
+     * Photon returns a single display name rather than first/last. Splitting
+     * it back apart guesses wrong on anyone with two given names or a
+     * multi-part surname, so the whole name is carried as one field.
+     */
+    leader?: { name: string };
+};
+
+type PhotonGroup = {
+    name: string;
+    slug: string;
+    type: string;
+    subtype: string | null;
+    description: string | null;
+    contactEmail: string | null;
+    imageUrl: string | null;
+    logoUrl: string | null;
+};
+
+type PhotonMember = {
+    role: string;
+    user: { name: string } | null;
+};
+
+/**
+ * The leader lives on the membership list, not on the group itself, so it
+ * costs an extra request per group. Failures are swallowed: a missing leader
+ * hides one line, while throwing would take down the whole page.
+ */
+async function fetchLeader(slug: string): Promise<Group["leader"]> {
+  try {
+    const res = await fetch(
+      `${API}/groups/${encodeURIComponent(slug)}/members`,
+      REVALIDATE,
+    );
+    if (!res.ok) return undefined;
+
+    const members = (await res.json()) as PhotonMember[];
+    const leader = members.find((m) => m.role === "leader");
+    return leader?.user?.name ? { name: leader.user.name } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function toGroup(g: PhotonGroup, leader?: Group["leader"]): Group {
+  return {
+    name: g.name,
+    slug: g.slug,
+    subtype: g.subtype,
+    // `logoUrl` is the square mark the old Lepton `image` field held; the
+    // separate `imageUrl` is a wide banner and would break the avatar layout.
+    image: g.logoUrl ?? undefined,
+    contact_email: g.contactEmail ?? undefined,
+    description: g.description ?? undefined,
+    leader,
+  };
+}
+
+export async function getGroup(slug: string): Promise<Group | null> {
+  const res = await fetch(
+    `${API}/groups/${encodeURIComponent(slug)}`,
+    REVALIDATE,
+  );
+  if (!res.ok) return null;
+
+  const group = (await res.json()) as PhotonGroup;
+  return toGroup(group, await fetchLeader(slug));
+}
+
+/**
+ * Groups of one type, newest API shape mapped to the one the components use.
+ *
+ * `subtype` narrows the result here rather than in the query string: Photon's
+ * list endpoint filters on type only. Leaders are fetched concurrently so the
+ * page waits for the slowest one, not the sum of them.
+ */
+export async function getGroupsByType(
+  type: string,
+  subtype?: string,
+): Promise<Group[]> {
+  const res = await fetch(
+    `${API}/groups?type=${encodeURIComponent(type)}`,
+    REVALIDATE,
+  );
+  if (!res.ok) return [];
+
+  const all = (await res.json()) as PhotonGroup[];
+  const groups = subtype ? all.filter((g) => g.subtype === subtype) : all;
+
+  return Promise.all(
+    groups.map(async (g) => toGroup(g, await fetchLeader(g.slug))),
+  );
+}


### PR DESCRIPTION
Gruppedata er det eneste wikien henter fra Lepton, og Lepton skal avvikles. Dataene finnes nå i Photon.

## Formen er en annen

| Lepton | Photon |
|---|---|
| `image` | `logoUrl` (`imageUrl` er en bred banner og ville brutt avatar-layouten) |
| `contact_email` | `contactEmail` |
| `leader` på gruppa | ligger på `/groups/{slug}/members`, rollen `leader` |
| `?subtype=` i spørringen | finnes ikke — Photon filtrerer bare på type |

Et kartleggingslag i `lib/group.ts` oversetter til formen komponentene allerede bruker, så endringene i dem er små. Ledere hentes parallelt, så siden venter på den tregeste og ikke på summen.

**Lederen bærer nå ett navnefelt.** Photon returnerer ett visningsnavn, og å dele det i fornavn og etternavn gjetter feil på alle med to fornavn eller sammensatt etternavn.

**Caching er endret fra `no-store` til fem minutter.** Gruppedata endres en gang i semesteret, mens `no-store` hentet hver gruppe på nytt for hver eneste besøkende — og med lederoppslaget i tillegg ville det blitt merkbart.

## Verifisert mot ekte data

`tsc` rent, `next build` grønt, og `/struktur` ble prerendret — altså hentet bygget faktisk fra Photon. I den genererte HTML-en:

- **21 av 21 gruppekort har leder**, så medlemsoppslaget virker
- **alle 20 interessegruppene er med i orgkartet**
- ingen referanser til `api.tihlde.org` igjen i `src/`

## Må ikke merges før backfillen er kjørt

`/struktur` har to seksjoner som filtrerer på subtype:

```
### Gruppe          → <GroupTypeSummarizer type="INTERESTGROUP" subtype="GRUPPE" />
### Idrettsgruppe   → <GroupTypeSummarizer type="INTERESTGROUP" subtype="IDRETTSGRUPPE" />
```

Photon har ennå ingen subtype-verdier i produksjon — kolonnen kommer med TIHLDE/Photon#462, og verdiene backfilles etterpå. Fram til da filtrerer begge seksjonene til null, og de står **tomme**. Det er synlig i byggets HTML: `poker` og `klatring` finnes bare i kartet, ikke som kort.

Orgkartet selv er trygt uansett — det faller tilbake til én flat seksjon med alle 20.

Rekkefølgen må altså være: merge #462 → deploy → kjør backfillen → merge denne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)