### PR TITLE
fix(grupper): interessegruppe uten subtype forsvant fra struktursiden

### DIFF
--- a/src/components/groups/OrgChart.tsx
+++ b/src/components/groups/OrgChart.tsx
@@ -1,4 +1,4 @@
-import { getGroup, getGroupsByType, Group } from "@/lib/group";
+import { getGroup, getGroupsByType, Group, interestSubtype } from "@/lib/group";
 import { OrgChartTree, type OrgChartData, type OrgNode } from "./OrgChartTree";
 
 function toNode(group: Group): OrgNode {
@@ -23,7 +23,10 @@ export async function OrgChart() {
   );
 
   const interestGroupsBySubtype = interestGroups.reduce<Record<string, Group[]>>((acc, group) => {
-    const subtype = group.subtype ?? "UKJENT";
+    // A group without a subtype is a gruppe, not a third category — see
+    // interestSubtype. Bucketing it under "UKJENT" dropped it off the chart
+    // entirely, because only the two known buckets are rendered.
+    const subtype = interestSubtype(group);
     if (!acc[subtype]) {
       acc[subtype] = [];
     }

--- a/src/lib/group.ts
+++ b/src/lib/group.ts
@@ -86,6 +86,19 @@ export async function getGroup(slug: string): Promise<Group | null> {
 }
 
 /**
+ * Which of the two interest-group categories a group belongs to.
+ *
+ * "Grupper" is the catch-all, straight from the definition further down the
+ * struktur page: a group that cannot be defined as an idrettsgruppe or an
+ * idrettslag is a gruppe. So a missing subtype is not an unknown third
+ * category — it is a gruppe, and treating it as unknown drops the group off
+ * the page entirely.
+ */
+export function interestSubtype(group: Pick<Group, "subtype">): string {
+  return group.subtype === "IDRETTSGRUPPE" ? "IDRETTSGRUPPE" : "GRUPPE";
+}
+
+/**
  * Groups of one type, newest API shape mapped to the one the components use.
  *
  * `subtype` narrows the result here rather than in the query string: Photon's
@@ -103,7 +116,9 @@ export async function getGroupsByType(
   if (!res.ok) return [];
 
   const all = (await res.json()) as PhotonGroup[];
-  const groups = subtype ? all.filter((g) => g.subtype === subtype) : all;
+  const groups = subtype
+    ? all.filter((g) => interestSubtype(g) === subtype)
+    : all;
 
   return Promise.all(
     groups.map(async (g) => toGroup(g, await fetchLeader(g.slug))),


### PR DESCRIPTION
Etter at subtype ble backfillet i Photon oppdaget jeg at **`trakk` forsvant helt fra `/struktur`** — verken i orgkartet eller som kort.

## Årsak

`trakk` har ingen subtype i Photon, akkurat som den ikke hadde det i Lepton. Kartet bøttet den under `"UKJENT"`, og bare `GRUPPE` og `IDRETTSGRUPPE` rendres. Seksjonene filtrerer på eksakt subtype, så den falt ut der også.

Dette var en eksisterende svakhet som ikke var synlig før, fordi den flate fallback-visningen tok med alle.

## Regelen står allerede på siden

Litt lenger ned i samme MDX-fil:

> Grupper (interessegrupper) — En gruppe som ikke kan defineres som Idrettsgruppe eller Idrettslag

`GRUPPE` er altså samlekategorien per definisjon. Manglende subtype er ikke en tredje kategori. Regelen ligger nå ett sted — `interestSubtype` — og brukes både av kartet og av seksjonsfiltreringen. Kvark gjør det samme i sitt orgkart.

## Verifisert

`tsc` rent, build grønt. I den prerendrede HTML-en: **41 gruppekort mot 40 før**, og `trakk` finnes nå to steder (kart + kort), som `poker` og `klatring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)